### PR TITLE
free allocated mdl in error path

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -72,6 +72,7 @@ NTSTATUS DmWriteMemory(
                 DbgPrint("[DM] DmWriteMemory: Invalid address.\n");
 #endif
 
+                IoFreeMdl(mdl);
                 return STATUS_ACCESS_VIOLATION;
             }
 


### PR DESCRIPTION
in one of the error paths an mdl is not freed.

```diff
...
!    mdl = IoAllocateMdl(DestAddress, Size, FALSE, FALSE, NULL);   <<< mdl allocated here
    if (mdl == NULL) {

#ifdef VERBOSE
        DbgPrint("[DM] DmWriteMemory: failed to create MDL at write.\n");
#endif

        return STATUS_INSUFFICIENT_RESOURCES;
    }

    __try {

        if (DestAddress >= MmSystemRangeStart)
            if (!MmIsAddressValid(DestAddress)) {

#ifdef VERBOSE
                DbgPrint("[DM] DmWriteMemory: Invalid address.\n");
#endif

!                return STATUS_ACCESS_VIOLATION;   <<< does not free mdl
            }
```